### PR TITLE
Runtime verification and README cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,16 +30,16 @@ The plugin adds a ``javarepl`` extension namespace with the following options:
 
 # Running
 
-Normally, Gradle runs using a rich console which adds a status line to depict build status.  It will also attempt to use an existing daemon to speed up builds.  Unfortunately, these two features prevent interactive console applications such as JavaREPL from running properly.  Therefore, Gradle should be run with the ``--console plain`` and ``--no-daemon`` options when running the ``javarepl`` task.  The following is an example command line to properly execute the ``javarepl`` task:
+Normally, Gradle will attempt to use an existing daemon to speed up builds.  Unfortunately, this feature prevents interactive console applications such as JavaREPL from running properly.  Therefore, Gradle should be started with the ``--no-daemon`` commmand line option when running the ``javarepl`` task.  The following is an example command line to properly execute the ``javarepl`` task:
 
 ```
-./gradlew javarepl --console plain --no-daemon
+./gradlew javarepl --no-daemon
 ```
 
 To reduce the overhead to typing this command line regularly, it is suggested that users add the following alias to their shell profile:
 
 ```
-alias grel='./gradlew javarepl --console plain --no-daemon"
+alias grel='./gradlew javarepl --no-daemon"
 ```
 
 With this alias, the ``grepl`` command will start a Java REPL using Gradle.

--- a/src/main/groovy/net/cockamamy/gradle/javarepl/JavaReplPlugin.groovy
+++ b/src/main/groovy/net/cockamamy/gradle/javarepl/JavaReplPlugin.groovy
@@ -14,14 +14,16 @@
  */
 package net.cockamamy.gradle.javarepl
 
+import org.gradle.api.GradleException
+import org.gradle.api.JavaVersion
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPlugin
 
-import java.util.concurrent.TimeUnit
-
 import static java.lang.ProcessBuilder.Redirect.INHERIT
 import static java.util.concurrent.TimeUnit.SECONDS
+import static org.gradle.api.JavaVersion.VERSION_1_8
+import static org.gradle.api.JavaVersion.VERSION_1_9
 
 class JavaReplPlugin implements Plugin<Project> {
 
@@ -33,6 +35,7 @@ class JavaReplPlugin implements Plugin<Project> {
         project.extensions.create("javarepl", JavaReplPluginExtension)
 
         project.afterEvaluate {
+
             // This plugin requires the Java plugin.  If it has not been applied
             // then add it ...
             if (!project.plugins.hasPlugin(JavaPlugin.class)) {
@@ -41,6 +44,12 @@ class JavaReplPlugin implements Plugin<Project> {
             }
 
             project.task('javarepl', dependsOn: 'testClasses') {
+
+                description = "Runs Java REPL with the classpath defined in the ${project.javarepl.baseConfiguration} configuration"
+
+                if (JavaVersion.current() != VERSION_1_8 && JavaVersion.current() != VERSION_1_9) {
+                    throw new GradleException("The javarepl plugin must be run with Java 8 or above")
+                }
 
                 final aConfiguration = project.configurations.maybeCreate(JAVAREPL_CONFIGURATION)
                     .extendsFrom(project.configurations.getByName(project.javarepl.baseConfiguration))
@@ -65,7 +74,6 @@ class JavaReplPlugin implements Plugin<Project> {
                 final Integer aTimeout = project.javarepl.timeout
                 aTimeout != null ? aProcess.waitFor(aTimeout, SECONDS) : aProcess.waitFor()
                 aProcess.destroyForcibly()
-
 
             }
 


### PR DESCRIPTION
  * Verifies that the JDK version is 1.8+ before starting JavaREPL
  * Removes unnecessary guidance regarding --console plain from README.md