### PR TITLE
Avoid long classpaths being truncated by command line length limits

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,6 @@ plugins {
     id "java-gradle-plugin"
     id "maven"
     id "com.gradle.plugin-publish" version "0.9.7"
-//    id "com.github.johnrengelman.shadow" version "1.2.4"
 }
 
 group = "net.cockamamy.gradle"

--- a/src/main/groovy/net/cockamamy/gradle/javarepl/JavaReplPlugin.groovy
+++ b/src/main/groovy/net/cockamamy/gradle/javarepl/JavaReplPlugin.groovy
@@ -51,16 +51,20 @@ class JavaReplPlugin implements Plugin<Project> {
 
                 final aCommand = [
                         'java',
-                        '-cp',
-                        aConfiguration.asPath,
                         'javarepl.Main'
                 ]
 
-                final aProcess = new ProcessBuilder(aCommand)
+                final aProcessBuilder = new ProcessBuilder(aCommand)
                     .redirectInput(INHERIT)
                     .redirectOutput(INHERIT)
                     .redirectError(INHERIT)
-                    .start()
+
+                // Specify the classpath as an environment variable rather than a command line option
+                // to allow for a longer classpath string than default shell command lines support ...
+                final aClasspath = aConfiguration.asPath
+                aProcessBuilder.environment().put("CLASSPATH", aClasspath)
+
+                final aProcess = aProcessBuilder.start()
 
                 final Integer aTimeout = project.javarepl.timeout
                 aTimeout != null ? aProcess.waitFor(aTimeout, SECONDS) : aProcess.waitFor()


### PR DESCRIPTION
  * Configure the classpath as an environment variable rather than a
command line option because environment variables have a no practical
length limit where command line length is limited
  * Removes cruft commented code