### PR TITLE
Configure heap and stack sizes used to run JavaREPL

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,10 @@ The plugin adds a ``javarepl`` extension namespace with the following options:
 |Extension Property|Description|Default Value|
 |------------------|-----------|-------------|
 |``configurations``|The list of Gradle configurations from which the classpath used to run Java REPL is derived|``["testRuntime"]``|
-|``version``|The version of Java REPL to install|428|
+|``heapSize``|The heap size used to run JavaREPL|``null``|
 |``timeout``|The length of time to run Java REPL before killing it.  This parameter is primarily use by unit tests. |``null``|
+|``stackSize``|The stack size used to run JavaREPL|``null``|
+|``version``|The version of Java REPL to install|428|
 
 # Running
 

--- a/src/main/groovy/net/cockamamy/gradle/javarepl/JavaReplPlugin.groovy
+++ b/src/main/groovy/net/cockamamy/gradle/javarepl/JavaReplPlugin.groovy
@@ -55,9 +55,13 @@ class JavaReplPlugin implements Plugin<Project> {
                     throw new GradleException("The javarepl plugin must be run with Java 8 or above")
                 }
 
-                final aCommand = ['java', 'javarepl.Main']
+                final aHeapSize = project.javarepl.heapSize
+                final aHeapArgument = aHeapSize ? "-Xms${aHeapSize}m -Xmx${aHeapSize}m" : ""
 
-                final aProcessBuilder = new ProcessBuilder(aCommand)
+                final aStackSize = project.javarepl.stackSize
+                final aStackArgument= aStackSize ? "-Xss${aStackSize}m" : ""
+
+                final aProcessBuilder = new ProcessBuilder("java", aHeapArgument, aStackArgument, "javarepl.Main")
                     .redirectInput(INHERIT)
                     .redirectOutput(INHERIT)
                     .redirectError(INHERIT)
@@ -72,7 +76,7 @@ class JavaReplPlugin implements Plugin<Project> {
 
                 // Configure the classpath as an environment variable rather than a command line option
                 // to allow for a longer classpath string than default shell command lines support ...
-                project.logger.debug("Starting JavaREPL with classpath: ${aClasspath}")
+                project.logger.debug("Using classpath ${aClasspath} for JavaREPL")
                 aProcessBuilder.environment().put("CLASSPATH", aClasspath)
 
                 final aProcess = aProcessBuilder.start()

--- a/src/main/groovy/net/cockamamy/gradle/javarepl/JavaReplPluginExtension.groovy
+++ b/src/main/groovy/net/cockamamy/gradle/javarepl/JavaReplPluginExtension.groovy
@@ -19,5 +19,7 @@ class JavaReplPluginExtension {
     List<String> configurations = ["testRuntime"]
     String version = "428"
     Integer timeout = null
+    Integer heapSize = null
+    Integer stackSize = null
 
 }

--- a/src/test/groovy/net/cockamamy/gradle/javarepl/JavaReplPluginFunctionalTest.groovy
+++ b/src/test/groovy/net/cockamamy/gradle/javarepl/JavaReplPluginFunctionalTest.groovy
@@ -32,7 +32,7 @@ class JavaReplPluginFunctionalTest extends Specification {
         myBuildFile = myTestProjectDir.newFile("build.gradle")
     }
 
-    def "Successfully start Java REPL"() {
+    def "Run Java REPL with default settings"() {
         given:
             myBuildFile << """
                 plugins {
@@ -129,7 +129,7 @@ class JavaReplPluginFunctionalTest extends Specification {
             result.task(":javarepl").outcome == UP_TO_DATE
 
         where:
-            gradleVersion << ["3.3", "3.4"]
+            gradleVersion << TEST_VERSIONS
 
     }
 
@@ -167,5 +167,107 @@ class JavaReplPluginFunctionalTest extends Specification {
 
     }
 
+    def "Run Java REPL with a custom heap size"() {
+        given:
+            myBuildFile << """
+                    plugins {
+                        id 'net.cockamamy.gradle.javarepl'
+                    }
+                    
+                    repositories {
+                        jcenter()
+                    }
+                    
+                    ext {
+                        javarepl {
+                            timeout = 10
+                            heapSize = 512
+                        }
+                    }
+                """
+
+        when:
+            final result = GradleRunner.create()
+                .withProjectDir(myTestProjectDir.root)
+                .withArguments("javarepl")
+                .withPluginClasspath()
+                .build()
+
+        then:
+            result.task(":javarepl").outcome == UP_TO_DATE
+
+        where:
+            gradleVersion << TEST_VERSIONS
+
+    }
+
+    def "Run Java REPL with a custom stack size"() {
+        given:
+            myBuildFile << """
+                        plugins {
+                            id 'net.cockamamy.gradle.javarepl'
+                        }
+                        
+                        repositories {
+                            jcenter()
+                        }
+                        
+                        ext {
+                            javarepl {
+                                timeout = 10
+                                stackSize = 256
+                            }
+                        }
+                    """
+
+        when:
+            final result = GradleRunner.create()
+                .withProjectDir(myTestProjectDir.root)
+                .withArguments("javarepl")
+                .withPluginClasspath()
+                .build()
+
+        then:
+            result.task(":javarepl").outcome == UP_TO_DATE
+
+        where:
+            gradleVersion << TEST_VERSIONS
+
+    }
+
+    def "Run Java REPL with a custom heap and stack size"() {
+        given:
+            myBuildFile << """
+                            plugins {
+                                id 'net.cockamamy.gradle.javarepl'
+                            }
+                            
+                            repositories {
+                                jcenter()
+                            }
+                            
+                            ext {
+                                javarepl {
+                                    timeout = 10
+                                    heapSize = 512
+                                    stackSize = 256
+                                }
+                            }
+                        """
+
+        when:
+            final result = GradleRunner.create()
+                .withProjectDir(myTestProjectDir.root)
+                .withArguments("javarepl")
+                .withPluginClasspath()
+                .build()
+
+        then:
+            result.task(":javarepl").outcome == UP_TO_DATE
+
+        where:
+            gradleVersion << TEST_VERSIONS
+
+    }
 
 }

--- a/test-repl.sh
+++ b/test-repl.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-./gradlew -b test-build.gradle --no-daemon javarepl
+./gradlew -b test-build.gradle --no-daemon --stacktrace javarepl


### PR DESCRIPTION
  * Adds the heapSize parameter which specifies the size of the heap to
configure for the JavaREPL process and associated test cases
  * Adds the stackSize parameter which specifies the size of the stack to
configure for the JavaREPL process and associated test cases
  * Modifies the test-repl.sh script to run Gradle with the --stacktrace
option to aide debugging test failures
  * Updates README.md to describe the new plugin parameters