### PR TITLE
Fixes broken custom heap size execution and configures dependent task

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The plugin adds a ``javarepl`` extension namespace with the following options:
 |Extension Property|Description|Default Value|
 |------------------|-----------|-------------|
 |``configurations``|The list of Gradle configurations from which the classpath used to run Java REPL is derived|``["testRuntime"]``|
+|``dependsOn``|The task on which the javarepl tasks depends for execution|``testClassses``|
 |``heapSize``|The heap size used to run JavaREPL|``null``|
 |``timeout``|The length of time to run Java REPL before killing it.  This parameter is primarily use by unit tests. |``null``|
 |``stackSize``|The stack size used to run JavaREPL|``null``|

--- a/src/main/groovy/net/cockamamy/gradle/javarepl/JavaReplPluginExtension.groovy
+++ b/src/main/groovy/net/cockamamy/gradle/javarepl/JavaReplPluginExtension.groovy
@@ -14,12 +14,31 @@
  */
 package net.cockamamy.gradle.javarepl
 
+import org.gradle.api.GradleException
+
 class JavaReplPluginExtension {
 
     List<String> configurations = ["testRuntime"]
-    String version = "428"
-    Integer timeout = null
+    String dependsOn = "testClasses"
     Integer heapSize = null
     Integer stackSize = null
+    Integer timeout = null
+    String version = "428"
+
+    void validate() {
+
+        if (!configurations) {
+            throw new GradleException("The JavaREPL plugin requires the specification of one or more configurations")
+        }
+
+        if (!dependsOn) {
+            throw new GradleException("The Java REPL plugin requires the specification of dependent task.")
+        }
+
+        if (!version) {
+            throw new GradleException("The Java REPL plugin requires the specification of a Java REPL version.")
+        }
+
+    }
 
 }

--- a/src/test/groovy/net/cockamamy/gradle/javarepl/JavaReplPluginFunctionalTest.groovy
+++ b/src/test/groovy/net/cockamamy/gradle/javarepl/JavaReplPluginFunctionalTest.groovy
@@ -58,7 +58,9 @@ class JavaReplPluginFunctionalTest extends Specification {
                 .build()
 
         then:
-            result.task(":javarepl").outcome == UP_TO_DATE
+            result.task(":javarepl").outcome == SUCCESS
+            result.task(":testClasses").outcome == SUCCESS || result.task(":testClasses").outcome == UP_TO_DATE
+            result.tasks.findIndexOf { it.path == ":testClasses" } < result.tasks.findIndexOf { it.path == ":javarepl"}
 
         where:
             gradleVersion << TEST_VERSIONS
@@ -92,7 +94,9 @@ class JavaReplPluginFunctionalTest extends Specification {
                 .build()
 
         then:
-            result.task(":javarepl").outcome == UP_TO_DATE
+            result.task(":javarepl").outcome == SUCCESS
+            result.task(":testClasses").outcome == SUCCESS || result.task(":testClasses").outcome == UP_TO_DATE
+            result.tasks.findIndexOf { it.path == ":testClasses" } < result.tasks.findIndexOf { it.path == ":javarepl"}
 
         where:
             gradleVersion << TEST_VERSIONS
@@ -126,7 +130,9 @@ class JavaReplPluginFunctionalTest extends Specification {
                 .build()
 
         then:
-            result.task(":javarepl").outcome == UP_TO_DATE
+            result.task(":javarepl").outcome == SUCCESS
+            result.task(":testClasses").outcome == SUCCESS || result.task(":testClasses").outcome == UP_TO_DATE
+            result.tasks.findIndexOf { it.path == ":testClasses" } < result.tasks.findIndexOf { it.path == ":javarepl"}
 
         where:
             gradleVersion << TEST_VERSIONS
@@ -194,7 +200,9 @@ class JavaReplPluginFunctionalTest extends Specification {
                 .build()
 
         then:
-            result.task(":javarepl").outcome == UP_TO_DATE
+            result.task(":javarepl").outcome == SUCCESS
+            result.task(":testClasses").outcome == SUCCESS || result.task(":testClasses").outcome == UP_TO_DATE
+            result.tasks.findIndexOf { it.path == ":testClasses" } < result.tasks.findIndexOf { it.path == ":javarepl"}
 
         where:
             gradleVersion << TEST_VERSIONS
@@ -228,7 +236,9 @@ class JavaReplPluginFunctionalTest extends Specification {
                 .build()
 
         then:
-            result.task(":javarepl").outcome == UP_TO_DATE
+            result.task(":javarepl").outcome == SUCCESS
+            result.task(":testClasses").outcome == SUCCESS || result.task(":testClasses").outcome == UP_TO_DATE
+            result.tasks.findIndexOf { it.path == ":testClasses" } < result.tasks.findIndexOf { it.path == ":javarepl"}
 
         where:
             gradleVersion << TEST_VERSIONS
@@ -263,7 +273,181 @@ class JavaReplPluginFunctionalTest extends Specification {
                 .build()
 
         then:
-            result.task(":javarepl").outcome == UP_TO_DATE
+            result.task(":javarepl").outcome == SUCCESS
+            result.task(":testClasses").outcome == SUCCESS || result.task(":testClasses").outcome == UP_TO_DATE
+            result.tasks.findIndexOf { it.path == ":testClasses" } < result.tasks.findIndexOf { it.path == ":javarepl"}
+
+        where:
+            gradleVersion << TEST_VERSIONS
+
+    }
+
+    def "Run Java REPL with a custom dependent task"() {
+        given:
+            myBuildFile << """
+                            plugins {
+                                id 'net.cockamamy.gradle.javarepl'
+                            }
+                            
+                            repositories {
+                                jcenter()
+                            }
+                            
+                            ext {
+                                javarepl {
+                                    timeout = 10
+                                    dependsOn = "classes"
+                                }
+                            }
+                        """
+
+        when:
+            final result = GradleRunner.create()
+                .withProjectDir(myTestProjectDir.root)
+                .withArguments("javarepl")
+                .withPluginClasspath()
+                .build()
+
+        then:
+            result.task(":javarepl").outcome == SUCCESS
+            result.task(":classes").outcome == SUCCESS || result.task(":classes").outcome == UP_TO_DATE
+            result.tasks.findIndexOf { it.path == ":classes" } < result.tasks.findIndexOf { it.path == ":javarepl"}
+
+        where:
+            gradleVersion << TEST_VERSIONS
+
+    }
+
+    def "Run Java REPL with an invalid custom dependent task"() {
+        given:
+            myBuildFile << """
+                            plugins {
+                                id 'net.cockamamy.gradle.javarepl'
+                            }
+                            
+                            repositories {
+                                jcenter()
+                            }
+                            
+                            ext {
+                                javarepl {
+                                    timeout = 10
+                                    dependsOn = "clazzes"
+                                }
+                            }
+                        """
+
+        when:
+            final result = GradleRunner.create()
+                .withProjectDir(myTestProjectDir.root)
+                .withArguments("javarepl")
+                .withPluginClasspath()
+                .buildAndFail()
+
+        then:
+            result.output.contains("Task with path 'clazzes' not found")
+
+        where:
+            gradleVersion << TEST_VERSIONS
+
+    }
+
+    def "Run Java REPL with a null custom dependent task"() {
+        given:
+            myBuildFile << """
+                            plugins {
+                                id 'net.cockamamy.gradle.javarepl'
+                            }
+                            
+                            repositories {
+                                jcenter()
+                            }
+                            
+                            ext {
+                                javarepl {
+                                    timeout = 10
+                                    dependsOn = null
+                                }
+                            }
+                        """
+
+        when:
+            final result = GradleRunner.create()
+                .withProjectDir(myTestProjectDir.root)
+                .withArguments("javarepl")
+                .withPluginClasspath()
+                .buildAndFail()
+
+        then:
+            result.output.contains("The Java REPL plugin requires the specification of dependent task.")
+
+        where:
+            gradleVersion << TEST_VERSIONS
+
+    }
+
+    def "Run Java REPL with a null JavaREPL version"() {
+        given:
+            myBuildFile << """
+                            plugins {
+                                id 'net.cockamamy.gradle.javarepl'
+                            }
+                            
+                            repositories {
+                                jcenter()
+                            }
+                            
+                            ext {
+                                javarepl {
+                                    timeout = 10
+                                    version = null
+                                }
+                            }
+                        """
+
+        when:
+            final result = GradleRunner.create()
+                .withProjectDir(myTestProjectDir.root)
+                .withArguments("javarepl")
+                .withPluginClasspath()
+                .buildAndFail()
+
+        then:
+            result.output.contains("The Java REPL plugin requires the specification of a Java REPL version.")
+
+        where:
+            gradleVersion << TEST_VERSIONS
+
+    }
+
+    def "Run Java REPL with a blank JavaREPL version"() {
+        given:
+            myBuildFile << """
+                            plugins {
+                                id 'net.cockamamy.gradle.javarepl'
+                            }
+                            
+                            repositories {
+                                jcenter()
+                            }
+                            
+                            ext {
+                                javarepl {
+                                    timeout = 10
+                                    version = ""
+                                }
+                            }
+                        """
+
+        when:
+            final result = GradleRunner.create()
+                .withProjectDir(myTestProjectDir.root)
+                .withArguments("javarepl")
+                .withPluginClasspath()
+                .buildAndFail()
+
+        then:
+            result.output.contains("The Java REPL plugin requires the specification of a Java REPL version.")
 
         where:
             gradleVersion << TEST_VERSIONS


### PR DESCRIPTION
  * Adds the dependsOn parameter to specify the task on which the
javarepl should depend.  It defaults to the testClasses task.
  * Fixes creation of the command line when no heap size and/or stack
size is specified.  Previously, blank values were put in the list passed
on to the ProcessBuilder which caused JavaREPL to fail.  Now, nothing is
added to list when these parameters are not specified.
  * Moves the execution of the logic of the task to the doLast method to
start JavaREPL after dependent tasks have successfully executed
  * Adds the JavaReplPluginExtension.validate method to verify the
values of the plugin parameters
  * Adds test cases for invalid version, configurations, and dependsOn
values, as well as, the behavior of the new dependsOn parameter