### PR TITLE
Update version and fix minor issues for the 1.0.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,26 @@
 
 This plugin runs [JavaREPL](http://www.javarepl.com) within the context a Gradle build file.  It configures the classpath used by javarepl to resolve classes to include all [`testRuntime`](https://docs.gradle.org/current/userguide/java_plugin.html#sec:java_plugin_and_dependency_management) dependencies, as well as, the compile and test artifacts for this project.  Using this plugin, developers can easily explore and execute different aspects of their projects via a REPL.
 
-# Installation 
+The following is a sample of the plugin output:
+
+```
+➜ gradle-javarepl-plugin git:(jsb/release-1.0.0) ✗ ./gradlew --no-daemon --console plain javarepl
+:compileJava NO-SOURCE
+:processResources
+:classes
+:compileTestJava NO-SOURCE
+:processTestResources NO-SOURCE
+:testClasses UP-TO-DATE
+:javarepl
+
+
+Welcome to JavaREPL version 428 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_92)
+Type expression to evaluate, :help for more options or press tab to auto-complete.
+Connected to local instance at http://localhost:63534
+java>
+```
+
+# Installation
 
 **N.B.** This plugin requires JDK 8+.  Java 7 and below are **not** supported.
 
@@ -33,16 +52,16 @@ The plugin adds a ``javarepl`` extension namespace with the following options:
 
 # Running
 
-Normally, Gradle will attempt to use an existing daemon to speed up builds.  Unfortunately, this feature prevents interactive console applications such as JavaREPL from running properly.  Therefore, Gradle should be started with the ``--no-daemon`` commmand line option when running the ``javarepl`` task.  The following is an example command line to properly execute the ``javarepl`` task:
+Normally, Gradle will attempt to use an existing daemon to speed up builds.  Unfortunately, this feature prevents interactive console applications such as JavaREPL from running properly.  Therefore, Gradle should be started with the ``--no-daemon`` commmand line option when running the ``javarepl`` task.  In addition to the daemon issue, Gradle's rich console can interfere with the JavaREPL's operations.  Running the task with the ``--console plain`` option will disable the rich console to avoid these potential issues.  The following is an example command line to properly execute the ``javarepl`` task:
 
 ```
-./gradlew javarepl --no-daemon
+./gradlew javarepl --no-daemon --console plain
 ```
 
 To reduce the overhead to typing this command line regularly, it is suggested that users add the following alias to their shell profile:
 
 ```
-alias grel='./gradlew javarepl --no-daemon'
+alias grel='./gradlew javarepl --no-daemon --console plain'
 ```
 
 With this alias, the ``grepl`` command will start a Java REPL using Gradle.

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ plugins {
 }
 
 group = "net.cockamamy.gradle"
-version = "0.1.0"
+version = "1.0.0"
 def pluginId = "${group}.javarepl"
 
 sourceCompatibility = "1.8"

--- a/src/main/groovy/net/cockamamy/gradle/javarepl/JavaReplPlugin.groovy
+++ b/src/main/groovy/net/cockamamy/gradle/javarepl/JavaReplPlugin.groovy
@@ -76,6 +76,7 @@ class JavaReplPlugin implements Plugin<Project> {
                     project.logger.debug("Using classpath ${aClasspath} for JavaREPL")
                     aProcessBuilder.environment().put("CLASSPATH", aClasspath)
 
+                    println(System.lineSeparator())
                     final aProcess = aProcessBuilder.start()
                     final Integer aTimeout = project.javarepl.timeout
                     aTimeout != null ? aProcess.waitFor(aTimeout, SECONDS) : aProcess.waitFor()

--- a/test-build.gradle
+++ b/test-build.gradle
@@ -3,7 +3,7 @@ buildscript {
         flatDir dirs: "build/libs"
     }
     dependencies {
-        classpath "net.cockamamy.gradle:gradle-javarepl-plugin:0.1.0"
+        classpath "net.cockamamy.gradle:gradle-javarepl-plugin:1.0.0"
     }
 }
 

--- a/test-repl.sh
+++ b/test-repl.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-./gradlew -b test-build.gradle --no-daemon --stacktrace javarepl
+./gradlew -b test-build.gradle --no-daemon --stacktrace --console plain javarepl


### PR DESCRIPTION
  * Set version to 1.0.0 in build.gradle and update test-build.gradle to
use the 1.0.0 version of the plugin jar
  * Emit a newline before executing to ensure clean spacing between
Gradle build output and JavaREPL's welcome message
  * Update README.md to provide guidance on using --console plain and
modify the test-repl.sh script to run Gradle with this option